### PR TITLE
The metapackage "Microsoft.AspNetCore.App" should not have a version

### DIFF
--- a/src/KongConfigurationValidation/KongConfigurationValidation.csproj
+++ b/src/KongConfigurationValidation/KongConfigurationValidation.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/test/KongConfigurationValidation.Tests/KongConfigurationValidation.Tests.csproj
+++ b/test/KongConfigurationValidation.Tests/KongConfigurationValidation.Tests.csproj
@@ -4,13 +4,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
     <PackageReference Include="System.Reactive" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\KongConfigurationValidation\KongConfigurationValidation.csproj" />
   </ItemGroup>


### PR DESCRIPTION
> We recommend relying on the implicit version specified by the SDK and not explicitly setting the version number on the package reference.

https://docs.microsoft.com/en-us/aspnet/core/fundamentals/metapackage-app?view=aspnetcore-2.1